### PR TITLE
graalvm doesn't work with java-version 17, has to be 17.0.12

### DIFF
--- a/src/.github/workflows/matrix_commons.js
+++ b/src/.github/workflows/matrix_commons.js
@@ -64,8 +64,10 @@ function configureJavaDefaults(matrix, distributionAxis = javaDistributionAxis, 
 	matrix.addAxis(versionAxis);
 	matrix.addAxis(operatingSystemAxis);
 
-	// graalvm requires at least jdk 17
+	// graalvm requires at least jdk 17 but for jdk 17 only jdk 17.0.12 is supported (but rewriting 17 to 17.0.12 has
+	// other implications). Thus, to keep it simple, we don't support jdk 11 and 17 for graalvm
 	matrix.exclude({java_distribution: 'graalvm', java_version: '11'});
+	matrix.exclude({java_distribution: 'graalvm', java_version: '17'});
 
 	// dragonwell doesn't support macOS (arm64)
 	matrix.exclude({java_distribution: 'dragonwell', os: 'macos-latest'});


### PR DESCRIPTION
Since using a specific version has other unwanted side effects we simply drop the support for jdk 17 as well, i.e. only include jdk21 for graalvm for now



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/github-commons/blob/v3.0.1/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
