### PR TITLE
use collaborators/.../permission to infer reviewer permissions

### DIFF
--- a/src/.github/workflows/cleanup.yml
+++ b/src/.github/workflows/cleanup.yml
@@ -48,10 +48,10 @@ jobs:
           status=$(curl -L -s -o /dev/null -w '%{http_code}' \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/$repo/collaborators/$user"
+            "https://api.github.com/repos/$repo/collaborators/$user/permission"
           )
           echo "status $status for user $user"
-          if [ "$status" = "204" ]; then
+          if [ "$status" = "200" ]; then
             echo "reviewer=$user" >> $GITHUB_OUTPUT
           else
             echo "reviewer=" >> $GITHUB_OUTPUT


### PR DESCRIPTION
seems like the term collaborators is overloaded in the github-api. As it seems collaborators/${user} only returns 204 if the user has at least maintainer permissions. I expected it returns 204 whenever the user is somehow still collaborating in the sense of it is still in the list of collaborators in the repo settings somehow (directly or indirectly via teams or implicitly via org etc.)

so for a user with write permissions collaborators/${user} returned 404 where collaborators/${user}/permission returns 200 -- nice design GitHub



______________________________________
I confirm that I have read the [Contributor Agreement v1.1](https://github.com/tegonal/github-commons/blob/v6.0.0/.github/Contributor%20Agreement.txt), agree to be bound on them and confirm that my contribution is compliant.
